### PR TITLE
feat: wait sync when it reaches rate limit.

### DIFF
--- a/src/strava_backup/config.py
+++ b/src/strava_backup/config.py
@@ -63,6 +63,13 @@ class SyncConfig:
     streams: bool = True
     comments: bool = True
 
+    # Rate limit handling
+    # If True, API calls will sleep and retry on Strava 429s.
+    # If False, the sync will stop early when rate limited.
+    wait_on_rate_limit: bool = True
+    # Safety cap to avoid sleeping indefinitely (seconds).
+    max_rate_limit_wait_seconds: int = 2 * 60 * 60
+
 
 @dataclass
 class Config:
@@ -196,6 +203,15 @@ def _load_from_file(path: Path, config: Config) -> Config:
         config.sync.photos = sync.get("photos", config.sync.photos)
         config.sync.streams = sync.get("streams", config.sync.streams)
         config.sync.comments = sync.get("comments", config.sync.comments)
+        config.sync.wait_on_rate_limit = sync.get(
+            "wait_on_rate_limit", config.sync.wait_on_rate_limit
+        )
+        config.sync.max_rate_limit_wait_seconds = int(
+            sync.get(
+                "max_rate_limit_wait_seconds",
+                config.sync.max_rate_limit_wait_seconds,
+            )
+        )
 
     return config
 


### PR DESCRIPTION
When I ran `strava-backup sync` I ran into this error message.

```
$ strava-backup sync
Starting sync
Syncing for athlete: soichi_hayashi
Syncing activities for soichi_hayashi...
Found 264 activities to process (264 new/updated, 0 retries)
Found 264 activities to process
  [1/264] Afternoon Walk (20251208T224852) - 1.5 km
  [2/264] Evening Walk (20251205T042204) - 1.3 km
  [3/264] Afternoon Walk (20251205T011609) - 0.8 km
Error processing activity 16644672763: 429 Client Error: Too Many Requests [Rate Limit Exceeded: [{'resource': 'Application', 'field': 'read rate limit', 'code': 'exceeded'}]]
Traceback (most recent call last):
```

This PR tries to work around this by waiting before resuming sync